### PR TITLE
support parsing of relations R() and functions f() with zero arguments

### DIFF
--- a/backend/src/main/kotlin/kalkulierbar/parsers/FirstOrderParser.kt
+++ b/backend/src/main/kotlin/kalkulierbar/parsers/FirstOrderParser.kt
@@ -156,7 +156,10 @@ class FirstOrderParser : PropositionalParser() {
         consume(TokenType.LPAREN)
 
         // Relation may have an arbitrary amount of argument terms
-        val arguments = mutableListOf(parseTerm())
+        val arguments = mutableListOf<FirstOrderTerm>()
+        if (! nextTokenIs(TokenType.RPAREN)) {
+            arguments.add(parseTerm())
+        }
         while (nextTokenIs(TokenType.COMMA)) {
             consume()
             arguments.add(parseTerm())
@@ -205,7 +208,10 @@ class FirstOrderParser : PropositionalParser() {
     private fun parseFunction(identifier: String): FirstOrderTerm {
         consume(TokenType.LPAREN)
 
-        val arguments = mutableListOf(parseTerm())
+        val arguments = mutableListOf<FirstOrderTerm>()
+        if (! nextTokenIs(TokenType.RPAREN)) {
+            arguments.add(parseTerm())
+        }
         while (nextTokenIs(TokenType.COMMA)) {
             consume()
             arguments.add(parseTerm())


### PR DESCRIPTION
I wanted to input a relation with zero arguments into the first order input. Simplest example is to enter `S() & !S()` in https://kbar.app/fo-tableaux. However, I got a parsing error `Expected identifier but got ')' at position 3`.

So I created a fix to correctly to parse the relations and functions with zero arguments.